### PR TITLE
Add unique id in lists when creating a user during onboarding

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -179,7 +179,21 @@ app.post("/api/users", async (req: Request, res: Response) => {
             userName: username,
             email,
             age,
-            groups: [],
+            groups: [{
+                name: "test", // Initialize with an empty name or other properties as needed
+                members: [],
+                admin: "test",
+                lists: [{
+                    list_id: new mongoose.Types.ObjectId().toString(),
+                    name: "Favorite Movies",
+                    list_type: "user",
+                    movies: [],
+                    members: [],
+                    date_created: new Date(),
+                    description: "A list of favorite movies.",
+                    isPublic: true,
+                }],
+            },],
             badges: ["New User"],
             lists: [fakeTop5MoviesList],
             actor: [],


### PR DESCRIPTION
fixes #109


- The error is a MongoDB duplicate key error, indicating that you're trying to insert a document into the users collection where the groups.lists.list_id field is null, which violates a unique index constraint.
---

- In future, we need to implement better logic to handle onboarding process.
