### PR TITLE
Add margin to dock to fit safari browser

### DIFF
--- a/client/src/components/ui/DockBar.tsx
+++ b/client/src/components/ui/DockBar.tsx
@@ -19,7 +19,7 @@ export function DockDemo() {
     const isActive = (path: string) => location.pathname === path
 
     return (
-        <div className="relative w-[335px]">
+        <div className="relative w-[335px] top-[-30px]">
             <Dock magnification={60} distance={60} className="gap-8">
                 <DockIcon
                     className={`bg-black/10 dark:bg-white/10 p-3 ${isActive("/") ? "bg-primary" : ""}`}


### PR DESCRIPTION
fix: #176 
<img width="462" alt="Screenshot 2024-10-16 at 3 29 51 AM" src="https://github.com/user-attachments/assets/d1a6be8d-ef66-4c6d-b948-e32f53cc3842">
