### PR TITLE
Fix for movies with no release date

### DIFF
--- a/client/src/pages/MoviePage/MovieDetailPage.tsx
+++ b/client/src/pages/MoviePage/MovieDetailPage.tsx
@@ -274,7 +274,10 @@ const MovieDetailPage: React.FC = () => {
                                     {movie.runtime % 60}m
                                 </div>
                                 <div>
-                                    {new Date(movie.release_date).getFullYear()}
+                                    {movie.release_date
+                                        ? new Date(movie.release_date).getFullYear()
+                                        : "- -"
+                                    }
                                 </div>
                             </div>
 
@@ -298,9 +301,10 @@ const MovieDetailPage: React.FC = () => {
                                         Release Date
                                     </span>
                                     <p>
-                                        {new Date(
-                                            movie.release_date
-                                        ).toLocaleDateString()}
+                                        {movie.release_date
+                                            ? new Date(movie.release_date).toLocaleDateString()
+                                            : "Not released yet"
+                                        }
                                     </p>
                                 </div>
                                 <div>

--- a/server/models/movie.ts
+++ b/server/models/movie.ts
@@ -4,7 +4,7 @@ export interface MovieInList {
     movie_id: string
     title: string
     poster_path: string
-    release_date: string
+    release_date?: string
     genre_ids?: number[]
 }
 
@@ -12,6 +12,6 @@ export const movieInListSchema = new Schema<MovieInList>({
     movie_id: { type: String, required: true },
     title: { type: String, required: true },
     poster_path: { type: String, required: true },
-    release_date: { type: String, required: true },
+    release_date: { type: String },
     genre_ids: [{ type: Number }],
 })


### PR DESCRIPTION
Fixing for adding movies with no release date (not release yet/ not available)
Here is the preview of the changes:

- Now movies with no release date like dacoit can be added to top 5 movies list while onboarding
- and prev they also cant be added to journal, but now they can be added to it as well
- in movies page, where Invalid data was shown for release date, replaced it with Not released yet, and in year with - - to have better experience in frontend

fixes #204 
