### PR TITLE
Disable selection of future dates

### DIFF
--- a/client/src/components/ui/calendar.tsx
+++ b/client/src/components/ui/calendar.tsx
@@ -51,6 +51,7 @@ function Calendar({
                 day_hidden: "invisible",
                 ...classNames,
             }}
+            disabled={{ after: new Date() }}
             components={{
                 IconLeft: () => <ChevronLeft className="h-4 w-4" />,
                 IconRight: () => <ChevronRight className="h-4 w-4" />,

--- a/client/src/pages/Journal/JournalPage.tsx
+++ b/client/src/pages/Journal/JournalPage.tsx
@@ -79,7 +79,14 @@ const JournalPage: React.FC = () => {
     }
 
     const handleAddEntry = async () => {
-        if (!selectedMovie || !dateWatched) return
+        if (!selectedMovie) {
+            toast.error("Please select a movie to add to the journal.") 
+            return
+        }
+        if(!dateWatched) {
+            toast.error("Please pick up a date to add to the journal.")
+            return
+        }
         setLoading(true) // Show loading spinner while sending
         try {
             await addJournalEntry.mutateAsync({


### PR DESCRIPTION
fixes #236 

Changes

- Now future date selection is disabled

@daccotta Is this newly added feature good to go?
- Also added an error toast message when a user tries to submit before entering the movie - earlier nothing happened when clicked like this - enhances user interaction and experience

Here is a short preview of the changes reflected

https://github.com/user-attachments/assets/85e96d2c-d70c-4207-af70-d6d4ee37fbca

